### PR TITLE
Add JWT authentication for admin dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ DATABASE_PATH=./data/ads.db
 GAM_NETWORK_ID=22904833613
 
 # Security Configuration (Optional)
+ADMIN_USERNAME=admin
 ADMIN_PASSWORD=
 JWT_SECRET=your-super-secure-secret-key-change-in-production
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.4.0",
         "express": "^4.19.0",
         "helmet": "^7.1.0",
+        "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0"
       },
       "devDependencies": {
@@ -619,6 +620,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -1081,6 +1088,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -2952,6 +2968,61 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2992,11 +3063,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "lite-ad-server",
   "version": "1.0.0",
@@ -7,8 +6,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",
-    "test": "node --test test/**/*.test.js",
-    "test:coverage": "node --test --experimental-test-coverage test/**/*.test.js",
+    "test": "node --test test/*.test.js",
+    "test:coverage": "node --test --experimental-test-coverage test/*.test.js",
     "lint": "eslint src --max-warnings=0",
     "lint:fix": "eslint src --fix",
     "docker:build": "docker build -t lite-ad-server:latest .",
@@ -24,30 +23,38 @@
     "quality": "npm run check:full",
     "prepare": "npm run check"
   },
-  "keywords": ["ad-server", "google-ad-manager", "nodejs", "express"],
+  "keywords": [
+    "ad-server",
+    "google-ad-manager",
+    "nodejs",
+    "express"
+  ],
   "license": "MIT",
   "dependencies": {
-    "express": "^4.19.0",
     "better-sqlite3": "^9.0.0",
-    "dotenv": "^16.4.0",
-    "morgan": "^1.10.0",
     "cors": "^2.8.5",
-    "helmet": "^7.1.0"
+    "dotenv": "^16.4.0",
+    "express": "^4.19.0",
+    "helmet": "^7.1.0",
+    "jsonwebtoken": "^9.0.2",
+    "morgan": "^1.10.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.2",
     "eslint": "^8.57.0",
     "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
-    "eslint-plugin-import": "^2.29.0"
+    "nodemon": "^3.0.2"
   },
   "engines": {
     "node": ">=20.0.0",
     "npm": ">=9.0.0"
   },
   "eslintConfig": {
-    "extends": ["standard"],
+    "extends": [
+      "standard"
+    ],
     "env": {
       "node": true,
       "es2022": true
@@ -58,7 +65,10 @@
     },
     "rules": {
       "no-console": "off",
-      "semi": ["error", "always"]
+      "semi": [
+        "error",
+        "always"
+      ]
     }
   }
 }

--- a/src/public/admin.html
+++ b/src/public/admin.html
@@ -24,6 +24,57 @@
       margin: 0 auto;
       padding: 20px;
     }
+
+    .login-modal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.6);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+    }
+
+    .login-box {
+      background: white;
+      padding: 30px;
+      border-radius: 8px;
+      width: 320px;
+      box-shadow: 0 10px 25px rgba(0,0,0,0.2);
+    }
+
+    .login-box h2 {
+      margin-bottom: 15px;
+      text-align: center;
+    }
+
+    .login-box input {
+      width: 100%;
+      padding: 10px;
+      margin-bottom: 10px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+
+    .login-box button {
+      width: 100%;
+      padding: 10px;
+      border: none;
+      border-radius: 4px;
+      background: linear-gradient(135deg, #667eea, #764ba2);
+      color: white;
+      cursor: pointer;
+      font-weight: 600;
+    }
+
+    .login-box .error {
+      color: #dc3545;
+      text-align: center;
+      margin-top: 10px;
+    }
     
     .header {
       background: rgba(255, 255, 255, 0.95);
@@ -269,6 +320,15 @@
   </style>
 </head>
 <body>
+  <div id="loginModal" class="login-modal" style="display:none;">
+    <form id="loginForm" class="login-box">
+      <h2>Admin Login</h2>
+      <input type="text" id="loginUsername" placeholder="Username" required />
+      <input type="password" id="loginPassword" placeholder="Password" required />
+      <button type="submit">Login</button>
+      <div id="loginError" class="error" style="display:none;"></div>
+    </form>
+  </div>
   <div class="container">
     <div class="header">
       <h1>🚀 Lite Ad Server</h1>
@@ -354,10 +414,12 @@
     let isOnline = true;
     let refreshInterval;
     
-    // Initialize dashboard
+    // Initialize dashboard after checking auth
     document.addEventListener('DOMContentLoaded', function() {
-      loadDashboard();
-      startAutoRefresh();
+      if (checkAuth()) {
+        loadDashboard();
+        startAutoRefresh();
+      }
     });
     
     async function loadDashboard() {
@@ -375,8 +437,15 @@
       }
     }
     
+    function authorizedFetch(url, options = {}) {
+      const token = localStorage.getItem('jwt');
+      const headers = options.headers || {};
+      if (token) headers['Authorization'] = 'Bearer ' + token;
+      return fetch(url, { ...options, headers });
+    }
+
     async function loadStats() {
-      const response = await fetch('/admin/stats');
+      const response = await authorizedFetch('/admin/stats');
       if (!response.ok) throw new Error('Failed to fetch stats');
       
       const data = await response.json();
@@ -392,7 +461,7 @@
     }
     
     async function loadAnalytics() {
-      const response = await fetch('/admin/stats');
+      const response = await authorizedFetch('/admin/stats');
       if (!response.ok) throw new Error('Failed to fetch analytics');
       
       const data = await response.json();
@@ -416,7 +485,7 @@
     
     async function loadRecentEvents() {
       try {
-        const response = await fetch('/admin/data?limit=20');
+        const response = await authorizedFetch('/admin/data?limit=20');
         if (!response.ok) throw new Error('Failed to fetch events');
         
         const events = await response.json();
@@ -496,10 +565,55 @@
     }
     
     // Handle page visibility for performance
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = document.getElementById('loginUsername').value.trim();
+      const password = document.getElementById('loginPassword').value;
+
+      try {
+        const res = await fetch('/api/auth/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username, password })
+        });
+
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ error: 'Login failed' }));
+          document.getElementById('loginError').textContent = err.error || 'Login failed';
+          document.getElementById('loginError').style.display = 'block';
+          return;
+        }
+
+        const data = await res.json();
+        localStorage.setItem('jwt', data.token);
+        document.getElementById('loginModal').style.display = 'none';
+        document.getElementById('loginError').style.display = 'none';
+        loadDashboard();
+        startAutoRefresh();
+      } catch {
+        document.getElementById('loginError').textContent = 'Login failed';
+        document.getElementById('loginError').style.display = 'block';
+      }
+    });
+
+    function checkAuth() {
+      const token = localStorage.getItem('jwt');
+      if (!token) {
+        document.getElementById('loginModal').style.display = 'flex';
+        return false;
+      }
+      return true;
+    }
+
+    if (checkAuth()) {
+      loadDashboard();
+      startAutoRefresh();
+    }
+
     document.addEventListener('visibilitychange', function() {
       if (document.hidden) {
         stopAutoRefresh();
-      } else {
+      } else if (checkAuth()) {
         startAutoRefresh();
         loadDashboard();
       }

--- a/src/server.js
+++ b/src/server.js
@@ -7,7 +7,7 @@ require('dotenv').config();
 
 const adRoutes = require('./routes/ad');
 const trackRoutes = require('./routes/track');
-const adminRoutes = require('./routes/admin');
+const { adminRouter, authRouter } = require('./routes/admin');
 
 const app = express();
 
@@ -83,7 +83,8 @@ app.get('/health', (req, res) => {
 // API routes
 app.use('/api/ad', adRoutes);
 app.use('/api/track', trackRoutes);
-app.use('/admin', adminRoutes);
+app.use('/admin', adminRouter);
+app.use('/api/auth', authRouter);
 
 // 404 handler
 app.use((req, res) => {

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+const { test, describe, before, after } = require('node:test');
+const express = require('express');
+
+describe('Admin JWT auth', () => {
+  let server;
+  let port;
+
+  before(() => {
+    process.env.DATABASE_PATH = ':memory:';
+    process.env.ADMIN_USERNAME = 'admin';
+    process.env.ADMIN_PASSWORD = 'pass';
+    process.env.JWT_SECRET = 'testsecret';
+    // Initialize database in-memory
+    require('../src/config');
+    const { adminRouter, authRouter } = require('../src/routes/admin');
+    const app = express();
+    app.use(express.json());
+    app.use('/admin', adminRouter);
+    app.use('/api/auth', authRouter);
+    server = app.listen(0);
+    port = server.address().port;
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  test('login returns token and allows access', async () => {
+    const loginRes = await fetch(`http://localhost:${port}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'admin', password: 'pass' })
+    });
+    assert.strictEqual(loginRes.status, 200);
+    const data = await loginRes.json();
+    assert.ok(data.token);
+
+    const protectedRes = await fetch(`http://localhost:${port}/admin/health`, {
+      headers: { Authorization: `Bearer ${data.token}` }
+    });
+    assert.strictEqual(protectedRes.status, 200);
+  });
+});


### PR DESCRIPTION
## Summary
- secure admin routes with JWT middleware
- add `/api/auth/login` endpoint
- update admin UI with login form and token-based requests
- document admin credentials in `.env.example`
- include jsonwebtoken dependency
- add tests for login flow

## Testing
- `node node_modules/eslint/bin/eslint.js src --max-warnings=0`
- `npm test`
- `docker build` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876e0323d14832ba6596f192a0972e7