### PR TITLE
Add integration and security tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "eslint-plugin-import": "^2.29.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.1.1",
-        "nodemon": "^3.0.2"
+        "nodemon": "^3.0.2",
+        "supertest": "^6.3.3"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -130,6 +131,19 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -166,6 +180,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -417,6 +441,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -426,6 +457,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -806,6 +844,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -847,6 +908,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -1016,6 +1084,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1042,6 +1120,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/doctrine": {
@@ -1841,6 +1930,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -1969,6 +2065,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -4407,6 +4536,70 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
+      "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "lite-ad-server",
   "version": "1.0.0",
@@ -7,8 +6,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",
-    "test": "node --test test/**/*.test.js",
-    "test:coverage": "node --test --experimental-test-coverage test/**/*.test.js",
+    "test": "node --test test",
+    "test:coverage": "node --test --experimental-test-coverage test",
     "lint": "eslint src --max-warnings=0",
     "lint:fix": "eslint src --fix",
     "docker:build": "docker build -t lite-ad-server:latest .",
@@ -24,30 +23,38 @@
     "quality": "npm run check:full",
     "prepare": "npm run check"
   },
-  "keywords": ["ad-server", "google-ad-manager", "nodejs", "express"],
+  "keywords": [
+    "ad-server",
+    "google-ad-manager",
+    "nodejs",
+    "express"
+  ],
   "license": "MIT",
   "dependencies": {
-    "express": "^4.19.0",
     "better-sqlite3": "^9.0.0",
-    "dotenv": "^16.4.0",
-    "morgan": "^1.10.0",
     "cors": "^2.8.5",
-    "helmet": "^7.1.0"
+    "dotenv": "^16.4.0",
+    "express": "^4.19.0",
+    "helmet": "^7.1.0",
+    "morgan": "^1.10.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.2",
     "eslint": "^8.57.0",
     "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
-    "eslint-plugin-import": "^2.29.0"
+    "nodemon": "^3.0.2",
+    "supertest": "^6.3.3"
   },
   "engines": {
     "node": ">=20.0.0",
     "npm": ">=9.0.0"
   },
   "eslintConfig": {
-    "extends": ["standard"],
+    "extends": [
+      "standard"
+    ],
     "env": {
       "node": true,
       "es2022": true
@@ -58,7 +65,10 @@
     },
     "rules": {
       "no-console": "off",
-      "semi": ["error", "always"]
+      "semi": [
+        "error",
+        "always"
+      ]
     }
   }
 }

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -200,7 +200,7 @@ router.get('/health', (req, res) => {
     const totalEvents = db.prepare('SELECT COUNT(*) as count FROM analytics').get();
     const uniqueSlots = db.prepare('SELECT COUNT(DISTINCT slot) as count FROM analytics').get();
     const recentEvents = db.prepare(
-      'SELECT COUNT(*) as count FROM analytics WHERE timestamp > datetime("now", "-1 hour")'
+      "SELECT COUNT(*) as count FROM analytics WHERE timestamp > datetime('now', '-1 hour')"
     ).get();
 
     res.json({

--- a/src/server.js
+++ b/src/server.js
@@ -99,19 +99,24 @@ app.use((err, req, res, next) => {
 });
 
 const PORT = process.env.PORT || 4000;
-const server = app.listen(PORT, () => {
-  console.log(`🚀 Lite Ad Server running on port ${PORT}`);
-  console.log(`📊 Admin dashboard: http://localhost:${PORT}/admin`);
-  console.log(`📈 Health check: http://localhost:${PORT}/health`);
-});
 
-// Graceful shutdown
-process.on('SIGTERM', () => {
-  console.log('SIGTERM received, shutting down gracefully');
-  server.close(() => {
-    console.log('Process terminated');
-    process.exit(0);
+let server;
+
+if (require.main === module) {
+  server = app.listen(PORT, () => {
+    console.log(`🚀 Lite Ad Server running on port ${PORT}`);
+    console.log(`📊 Admin dashboard: http://localhost:${PORT}/admin`);
+    console.log(`📈 Health check: http://localhost:${PORT}/health`);
   });
-});
+
+  // Graceful shutdown
+  process.on('SIGTERM', () => {
+    console.log('SIGTERM received, shutting down gracefully');
+    server.close(() => {
+      console.log('Process terminated');
+      process.exit(0);
+    });
+  });
+}
 
 module.exports = app;

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -128,4 +128,3 @@ describe('Ad Tag Generation', () => {
   });
 });
 
-console.log('✅ All tests completed successfully!'); 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+const { describe, test, before } = require('node:test');
+const request = require('supertest');
+
+let app;
+
+describe('Integration Tests', () => {
+  before(() => {
+    process.env.DATABASE_PATH = ':memory:';
+    process.env.ADMIN_PASSWORD = '';
+    app = require('../src/server');
+  });
+
+  test('GET /health returns ok', async () => {
+    const res = await request(app).get('/health');
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.body.status, 'ok');
+  });
+
+  test('GET /api/ad serves script', async () => {
+    const res = await request(app).get('/api/ad').query({ slot: 'test-slot' });
+    assert.strictEqual(res.statusCode, 200);
+    assert.match(res.text, /googletag/);
+  });
+
+  test('POST /api/track saves event', async () => {
+    const res = await request(app)
+      .post('/api/track')
+      .send({ slot: 'test-slot', event: 'impression' });
+    assert.strictEqual(res.statusCode, 200);
+    assert.ok(res.body.success);
+  });
+
+  test('GET /admin/health returns healthy', async () => {
+    const res = await request(app).get('/admin/health');
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.body.status, 'healthy');
+  });
+
+  test('GET /admin/data summary', async () => {
+    const res = await request(app).get('/admin/data');
+    assert.strictEqual(res.statusCode, 200);
+    assert.ok(Array.isArray(res.body));
+  });
+
+  test('GET unknown route returns 404', async () => {
+    const res = await request(app).get('/does-not-exist');
+    assert.strictEqual(res.statusCode, 404);
+  });
+});

--- a/test/performance.test.js
+++ b/test/performance.test.js
@@ -14,9 +14,10 @@ describe('Performance Tests', () => {
   test('ad endpoint handles load quickly', async () => {
     const startMem = process.memoryUsage().heapUsed;
     const start = performance.now();
-    for (let i = 0; i < 20; i++) {
-      await request(app).get('/api/ad').query({ slot: 'load-slot' });
-    }
+    const requests = Array.from({ length: 20 }, () => 
+      request(app).get('/api/ad').query({ slot: 'load-slot' })
+    );
+    await Promise.all(requests);
     const duration = performance.now() - start;
     const endMem = process.memoryUsage().heapUsed;
     assert.ok(duration < 2000, `duration ${duration}`);

--- a/test/performance.test.js
+++ b/test/performance.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const { describe, test, before } = require('node:test');
+const { performance } = require('perf_hooks');
+const request = require('supertest');
+
+let app;
+
+describe('Performance Tests', () => {
+  before(() => {
+    process.env.DATABASE_PATH = ':memory:';
+    app = require('../src/server');
+  });
+
+  test('ad endpoint handles load quickly', async () => {
+    const startMem = process.memoryUsage().heapUsed;
+    const start = performance.now();
+    for (let i = 0; i < 20; i++) {
+      await request(app).get('/api/ad').query({ slot: 'load-slot' });
+    }
+    const duration = performance.now() - start;
+    const endMem = process.memoryUsage().heapUsed;
+    assert.ok(duration < 2000, `duration ${duration}`);
+    assert.ok(endMem - startMem < 50 * 1024 * 1024, 'memory usage within limits');
+  });
+});

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -1,0 +1,37 @@
+const assert = require('assert');
+const { describe, test, before } = require('node:test');
+const request = require('supertest');
+
+let app;
+
+describe('Security Tests', () => {
+  before(() => {
+    process.env.DATABASE_PATH = ':memory:';
+    process.env.RATE_LIMIT = '5';
+    app = require('../src/server');
+  });
+
+  test('rejects invalid slot input', async () => {
+    const res = await request(app).get('/api/ad').query({ slot: '<script>' });
+    assert.strictEqual(res.statusCode, 400);
+  });
+
+  test('prevents SQL injection attempt', async () => {
+    await request(app)
+      .post('/api/track')
+      .send({ slot: "'; DROP TABLE analytics;--", event: 'impression' });
+    const res = await request(app)
+      .post('/api/track')
+      .send({ slot: 'safe-slot', event: 'impression' });
+    assert.strictEqual(res.statusCode, 200);
+    assert.ok(res.body.success);
+  });
+
+  test('rate limiting works', async () => {
+    for (let i = 0; i < 5; i++) {
+      await request(app).get('/api/ad').query({ slot: 'rl-slot' });
+    }
+    const res = await request(app).get('/api/ad').query({ slot: 'rl-slot' });
+    assert.strictEqual(res.statusCode, 429);
+  });
+});


### PR DESCRIPTION
## Summary
- add integration, performance and security test suites
- fix admin health query quoting
- make `server.js` start only when run directly
- simplify test script

## Testing
- `./node_modules/.bin/eslint src --max-warnings=0`
- `npm test`
- `node --test --experimental-test-coverage test`
- `docker build -t lite-ad-server:latest .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876eb501014832bae7d2680375bac54