### PR TITLE
Add production deployment configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,4 @@ LOG_LEVEL=info
 
 # Rate Limiting (requests per minute)
 RATE_LIMIT=100
+\n# Caching (optional)\nREDIS_URL=redis://localhost:6379

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx eslint src --max-warnings=0
+      - run: node --test test/basic.test.js
+      - run: docker build -t lite-ad-server .
+      - run: docker images --format '{{.Size}}' lite-ad-server:latest

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ codex "implement JWT authentication for admin dashboard"
 
 📖 **See [CODEX_SETUP.md](./CODEX_SETUP.md) for detailed setup instructions**
 
+
+## Deployment
+For deployment options and runbooks, see [docs/deployment.md](docs/deployment.md) and [docs/runbook.md](docs/runbook.md).
+
 ## 📋 Next Features
 
 Check [NEXT_FEATURES.md](./NEXT_FEATURES.md) for upcoming enhancements:

--- a/deploy/fly.toml
+++ b/deploy/fly.toml
@@ -1,0 +1,32 @@
+app = "lite-ad-server"
+primary_region = "iad"
+kill_signal = "SIGINT"
+kill_timeout = 5
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "4000"
+
+[deploy]
+  strategy = "rolling"
+
+[[services]]
+  internal_port = 4000
+  protocol = "tcp"
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+  [[services.http_checks]]
+    path = "/health"
+    interval = 10000
+    timeout = 2000

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lite-ad-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: lite-ad-server
+  template:
+    metadata:
+      labels:
+        app: lite-ad-server
+    spec:
+      containers:
+        - name: app
+          image: lite-ad-server:latest
+          ports:
+            - containerPort: 4000
+          env:
+            - name: NODE_ENV
+              value: "production"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: lite-ad-server-pvc

--- a/deploy/kubernetes/ingress.yaml
+++ b/deploy/kubernetes/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: lite-ad-server
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: lite-ad-server
+                port:
+                  number: 80

--- a/deploy/kubernetes/pvc.yaml
+++ b/deploy/kubernetes/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lite-ad-server-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/kubernetes/service.yaml
+++ b/deploy/kubernetes/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: lite-ad-server
+spec:
+  selector:
+    app: lite-ad-server
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 4000
+  type: ClusterIP

--- a/deploy/render.yaml
+++ b/deploy/render.yaml
@@ -1,0 +1,16 @@
+services:
+  - type: web
+    name: lite-ad-server
+    runtime: node
+    region: oregon
+    plan: free
+    buildCommand: "npm ci && npm run lint && node --test"
+    startCommand: "node src/server.js"
+    healthCheckPath: /health
+    envVars:
+      - key: NODE_ENV
+        value: production
+    disks:
+      - name: data
+        mountPath: /app/data
+        sizeGB: 1

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "ecs" {
+  source = "terraform-aws-modules/ecs/aws"
+  cluster_name = var.cluster_name
+  container_insights = true
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,0 +1,9 @@
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "lite-ad-server"
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,17 @@
+version: "3.8"
+services:
+  adserver:
+    build: .
+    restart: always
+    environment:
+      NODE_ENV: production
+      PORT: 4000
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./data:/app/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,40 @@
+# Production Deployment Guide
+
+This document explains how to deploy **Lite Ad Server** across multiple targets.
+
+## Render.com
+1. Create a new Web Service using `deploy/render.yaml`.
+2. Enable automatic deploys from the `main` branch.
+3. Persist database by attaching a disk at `/app/data`.
+
+## Fly.io
+1. Install the [Fly CLI](https://fly.io/docs/hands-on/install-flyctl/).
+2. Run `fly launch` or use the provided `deploy/fly.toml`.
+3. Deploy with `fly deploy` and monitor using `fly status`.
+
+## Kubernetes
+1. Apply the manifests in `deploy/kubernetes/`:
+   ```bash
+   kubectl apply -f deploy/kubernetes/pvc.yaml
+   kubectl apply -f deploy/kubernetes/deployment.yaml
+   kubectl apply -f deploy/kubernetes/service.yaml
+   kubectl apply -f deploy/kubernetes/ingress.yaml
+   ```
+2. Ensure a persistent volume is provisioned for the database.
+
+## AWS ECS (via Terraform)
+1. Customize variables in `deploy/terraform/variables.tf`.
+2. Initialize and apply the configuration:
+   ```bash
+   cd deploy/terraform
+   terraform init
+   terraform apply
+   ```
+
+## Self-hosted VPS
+1. Use `docker-compose.prod.yml` for an easy deployment:
+   ```bash
+   docker compose -f docker-compose.prod.yml up -d
+   ```
+2. Set up a reverse proxy (Nginx/Caddy) for TLS termination.
+

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,33 @@
+# Operations Runbook
+
+This runbook covers routine tasks for maintaining **Lite Ad Server** in production.
+
+## Health Checks
+- Verify the `/health` endpoint returns status `ok`.
+- In Kubernetes, ensure pods are `Ready`.
+
+## Scaling
+- Increase replica count in `deploy/kubernetes/deployment.yaml`.
+- For Fly.io, run `fly scale count <n>`.
+
+## Backups
+- Backup the SQLite database periodically:
+  ```bash
+  cp data/ads.db data/ads.db.$(date +%F)
+  ```
+- Store backups securely off‑site.
+
+## Restores
+1. Stop the running application.
+2. Replace `data/ads.db` with the desired backup.
+3. Start the application and verify.
+
+## Logs
+- Use `docker compose logs -f` for local deployments.
+- For cloud targets, integrate with their logging solutions (Render events, Fly logs, CloudWatch, etc.).
+
+## Disaster Recovery
+- Maintain regular off-site backups.
+- Store Terraform state remotely (e.g., S3 with DynamoDB locking).
+- Document redeployment steps using `docs/deployment.md`.
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,23 @@
+const node = require('eslint-plugin-node');
+const importPlugin = require('eslint-plugin-import');
+const promise = require('eslint-plugin-promise');
+
+module.exports = [
+  {
+    files: ['src/**/*.js'],
+    ignores: ['node_modules/**'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    },
+    plugins: {
+      node,
+      import: importPlugin,
+      promise
+    },
+    rules: {
+      'no-console': 'off',
+      semi: ['error', 'always']
+    }
+  }
+];


### PR DESCRIPTION
## Summary
- add CI pipeline for lint, tests and container build
- document deployment options in docs/
- provide runbook for ops
- add Docker Compose production file
- add Render, Fly, Kubernetes and Terraform configs
- include ESLint flat config
- reference deployment docs in README

## Testing
- `npx eslint src --max-warnings=0`
- `node --test test/basic.test.js`
- `docker build -t lite-ad-server .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876f9cfee44832baea2907c43fbf1bd