### PR TITLE
Expand admin dashboard with campaign management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "dotenv": "^16.4.0",
         "express": "^4.19.0",
         "helmet": "^7.1.0",
-        "morgan": "^1.10.0"
+        "morgan": "^1.10.0",
+        "socket.io": "^4.7.5"
       },
       "devDependencies": {
         "eslint": "^8.57.0",
@@ -199,12 +200,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
+      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -507,6 +532,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -1194,6 +1228,61 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/es-abstract": {
@@ -4411,6 +4500,98 @@
         "node": ">=10"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -4863,6 +5044,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -5026,6 +5213,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "dotenv": "^16.4.0",
     "express": "^4.19.0",
     "helmet": "^7.1.0",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "socket.io": "^4.7.5"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,40 @@ const Database = require('better-sqlite3');
 const path = require('path');
 const fs = require('fs');
 
+// Default ad formats to seed database with basic options
+const defaultFormats = [
+  {
+    name: 'banner',
+    display_name: 'Banner Ad',
+    description: 'Standard rectangular banner advertisements',
+    default_settings: { sizes: ['728x90', '300x250', '970x250'] }
+  },
+  {
+    name: 'pushdown',
+    display_name: 'PushDown Banner',
+    description: 'Expandable banner that pushes content down',
+    default_settings: { defaultSize: '728x90', expandedSize: '728x300' }
+  },
+  {
+    name: 'interscroller',
+    display_name: 'Interscroller',
+    description: 'Full-screen ads between content sections',
+    default_settings: { triggerOffset: 50, duration: 5000 }
+  },
+  {
+    name: 'popup',
+    display_name: 'Popup/Modal',
+    description: 'Overlay-style advertisements',
+    default_settings: { delay: 3000, frequency: 'once_per_session' }
+  },
+  {
+    name: 'interstitial',
+    display_name: 'Interstitial',
+    description: 'Full-page advertisements',
+    default_settings: { allowSkip: true, skipDelay: 5 }
+  }
+];
+
 // Ensure data directory exists
 const dataDir = path.dirname(process.env.DATABASE_PATH || path.join(__dirname, '../data/ads.db'));
 if (!fs.existsSync(dataDir)) {
@@ -38,11 +72,64 @@ try {
       referer   TEXT,
       timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
     );
-    
+
+    CREATE TABLE IF NOT EXISTS ad_formats (
+      id INTEGER PRIMARY KEY,
+      name TEXT UNIQUE NOT NULL,
+      display_name TEXT NOT NULL,
+      description TEXT,
+      default_settings JSON,
+      required_dimensions JSON,
+      supported_features JSON,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE IF NOT EXISTS ad_campaigns (
+      id INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      format_id INTEGER REFERENCES ad_formats(id),
+      targeting_settings JSON,
+      schedule_settings JSON,
+      budget_settings JSON,
+      status TEXT DEFAULT 'draft',
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE IF NOT EXISTS ad_creatives (
+      id INTEGER PRIMARY KEY,
+      campaign_id INTEGER REFERENCES ad_campaigns(id),
+      name TEXT NOT NULL,
+      creative_data JSON,
+      preview_url TEXT,
+      status TEXT DEFAULT 'pending',
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
     CREATE INDEX IF NOT EXISTS idx_analytics_slot ON analytics(slot);
     CREATE INDEX IF NOT EXISTS idx_analytics_event ON analytics(event);
     CREATE INDEX IF NOT EXISTS idx_analytics_timestamp ON analytics(timestamp);
   `);
+
+  // Seed default ad formats if table is empty
+  const count = db.prepare('SELECT COUNT(*) as cnt FROM ad_formats').get().cnt;
+  if (count === 0) {
+    const insert = db.prepare(`
+      INSERT INTO ad_formats (name, display_name, description, default_settings)
+      VALUES (@name, @display_name, @description, @default_settings)
+    `);
+    const insertMany = db.transaction((formats) => {
+      for (const f of formats) {
+        insert.run({
+          name: f.name,
+          display_name: f.display_name,
+          description: f.description,
+          default_settings: JSON.stringify(f.default_settings || {})
+        });
+      }
+    });
+    insertMany(defaultFormats);
+    console.log('📦 Seeded default ad formats');
+  }
 
   console.log('✅ Database tables initialized');
 } catch (error) {
@@ -70,19 +157,29 @@ const statements = {
     LIMIT ?
   `),
   getSlotStats: db.prepare(`
-    SELECT 
+    SELECT
       slot,
       SUM(CASE WHEN event = 'impression' THEN 1 ELSE 0 END) as impressions,
       SUM(CASE WHEN event = 'click' THEN 1 ELSE 0 END) as clicks,
       ROUND(
-        CAST(SUM(CASE WHEN event = 'click' THEN 1 ELSE 0 END) AS FLOAT) / 
-        NULLIF(SUM(CASE WHEN event = 'impression' THEN 1 ELSE 0 END), 0) * 100, 
+        CAST(SUM(CASE WHEN event = 'click' THEN 1 ELSE 0 END) AS FLOAT) /
+        NULLIF(SUM(CASE WHEN event = 'impression' THEN 1 ELSE 0 END), 0) * 100,
         2
       ) as ctr
-    FROM analytics 
+    FROM analytics
     GROUP BY slot
     ORDER BY impressions DESC
-  `)
+  `),
+  getFormats: db.prepare('SELECT * FROM ad_formats ORDER BY id'),
+  insertFormat: db.prepare('INSERT INTO ad_formats (name, display_name, description, default_settings) VALUES (@name, @display_name, @description, @default_settings)'),
+  insertCampaign: db.prepare('INSERT INTO ad_campaigns (name, format_id, targeting_settings, schedule_settings, budget_settings, status) VALUES (@name, @format_id, @targeting_settings, @schedule_settings, @budget_settings, @status)'),
+  getCampaigns: db.prepare('SELECT * FROM ad_campaigns ORDER BY id'),
+  getCampaignById: db.prepare('SELECT * FROM ad_campaigns WHERE id = ?'),
+  updateCampaign: db.prepare('UPDATE ad_campaigns SET name=@name, format_id=@format_id, targeting_settings=@targeting_settings, schedule_settings=@schedule_settings, budget_settings=@budget_settings, status=@status WHERE id=@id'),
+  deleteCampaign: db.prepare('DELETE FROM ad_campaigns WHERE id = ?'),
+  insertCreative: db.prepare('INSERT INTO ad_creatives (campaign_id, name, creative_data, preview_url, status) VALUES (@campaign_id, @name, @creative_data, @preview_url, @status)'),
+  getCreative: db.prepare('SELECT * FROM ad_creatives WHERE id = ?'),
+  updateCreativeStatus: db.prepare('UPDATE ad_creatives SET status=@status WHERE id=@id')
 };
 
 // Graceful shutdown

--- a/src/public/admin.html
+++ b/src/public/admin.html
@@ -11,6 +11,29 @@
       padding: 0;
       box-sizing: border-box;
     }
+
+    .tabs {
+      display: flex;
+      gap: 10px;
+      margin-bottom: 20px;
+    }
+
+    .tabs button {
+      flex: 1;
+      padding: 10px;
+      border: none;
+      border-radius: 8px;
+      background: #eee;
+      cursor: pointer;
+    }
+
+    .tabs button.active {
+      background: #667eea;
+      color: #fff;
+    }
+
+    .tab-section { display: none; }
+    .tab-section.active { display: block; }
     
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
@@ -274,7 +297,25 @@
       <h1>🚀 Lite Ad Server</h1>
       <p>Real-time Analytics Dashboard</p>
     </div>
+
+    <nav class="tabs">
+      <button id="tabBtn-campaigns" onclick="showTab('campaigns')">Campaign Management</button>
+      <button id="tabBtn-creatives" onclick="showTab('creatives')">Creative Studio</button>
+      <button id="tabBtn-analytics" class="active" onclick="showTab('analytics')">Analytics</button>
+      <button id="tabBtn-settings" onclick="showTab('settings')">Settings</button>
+    </nav>
+
+    <section id="campaigns" class="tab-section">
+      <h2>Campaign Management</h2>
+      <p>Coming soon...</p>
+    </section>
+
+    <section id="creatives" class="tab-section">
+      <h2>Creative Studio</h2>
+      <p>Upload and preview creatives here.</p>
+    </section>
     
+    <section id="analytics" class="tab-section active">
     <div class="controls">
       <button class="btn" onclick="refreshData()">
         <span>🔄</span> Refresh Data
@@ -348,17 +389,39 @@
         </div>
       </div>
     </div>
+    </section>
+    <section id="settings" class="tab-section">
+      <h2>Settings</h2>
+      <p>Configure server options here.</p>
+    </section>
   </div>
 
+  <script src="/socket.io/socket.io.js"></script>
   <script>
     let isOnline = true;
     let refreshInterval;
+    let currentTab = 'analytics';
+    const socket = io();
+    socket.on('analytics', () => {
+      loadDashboard();
+    });
     
     // Initialize dashboard
     document.addEventListener('DOMContentLoaded', function() {
       loadDashboard();
       startAutoRefresh();
     });
+
+    function showTab(name) {
+      document.querySelectorAll('.tab-section').forEach(sec => {
+        sec.classList.remove('active');
+      });
+      document.querySelectorAll('.tabs button').forEach(btn => btn.classList.remove('active'));
+      document.getElementById(name).classList.add('active');
+      document.getElementById('tabBtn-' + name).classList.add('active');
+      currentTab = name;
+      if (name === 'analytics') loadDashboard();
+    }
     
     async function loadDashboard() {
       try {

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -31,6 +31,147 @@ const basicAuth = (req, res, next) => {
 // Apply basic auth to all admin routes
 router.use(basicAuth);
 
+// -----------------------
+// Format Management
+// -----------------------
+router.get('/api/formats', (req, res) => {
+  try {
+    const formats = statements.getFormats.all();
+    res.json(formats.map(f => ({
+      ...f,
+      default_settings: f.default_settings ? JSON.parse(f.default_settings) : {}
+    })));
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to load formats' });
+  }
+});
+
+router.post('/api/formats', (req, res) => {
+  try {
+    const { name, display_name: displayName, description, default_settings: defaultSettings } = req.body;
+    if (!name || !displayName) {
+      return res.status(400).json({ error: 'name and display_name required' });
+    }
+    statements.insertFormat.run({
+      name,
+      display_name: displayName,
+      description,
+      default_settings: JSON.stringify(defaultSettings || {})
+    });
+    res.json({ success: true });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to create format' });
+  }
+});
+
+// -----------------------
+// Campaign Management
+// -----------------------
+router.post('/api/campaigns', (req, res) => {
+  try {
+    const { name, format_id: formatId } = req.body;
+    if (!name || !formatId) {
+      return res.status(400).json({ error: 'name and format_id required' });
+    }
+    const result = statements.insertCampaign.run({
+      name,
+      format_id: formatId,
+      targeting_settings: JSON.stringify(req.body.targeting_settings || {}),
+      schedule_settings: JSON.stringify(req.body.schedule_settings || {}),
+      budget_settings: JSON.stringify(req.body.budget_settings || {}),
+      status: req.body.status || 'draft'
+    });
+    res.json({ id: result.lastInsertRowid });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to create campaign' });
+  }
+});
+
+router.get('/api/campaigns', (req, res) => {
+  try {
+    const campaigns = statements.getCampaigns.all();
+    res.json(campaigns);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to list campaigns' });
+  }
+});
+
+router.put('/api/campaigns/:id', (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    const existing = statements.getCampaignById.get(id);
+    if (!existing) return res.status(404).json({ error: 'Not found' });
+
+    statements.updateCampaign.run({
+      id,
+      name: req.body.name || existing.name,
+      format_id: req.body.format_id || existing.format_id,
+      targeting_settings: JSON.stringify(req.body.targeting_settings || existing.targeting_settings || {}),
+      schedule_settings: JSON.stringify(req.body.schedule_settings || existing.schedule_settings || {}),
+      budget_settings: JSON.stringify(req.body.budget_settings || existing.budget_settings || {}),
+      status: req.body.status || existing.status
+    });
+    res.json({ success: true });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to update campaign' });
+  }
+});
+
+router.delete('/api/campaigns/:id', (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    statements.deleteCampaign.run(id);
+    res.json({ success: true });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to delete campaign' });
+  }
+});
+
+// -----------------------
+// Creative Management
+// -----------------------
+router.post('/api/creatives', (req, res) => {
+  try {
+    const { campaign_id: campaignId, name, creative_data: creativeData, preview_url: previewUrl } = req.body;
+    if (!campaignId || !name) {
+      return res.status(400).json({ error: 'campaign_id and name required' });
+    }
+    const result = statements.insertCreative.run({
+      campaign_id: campaignId,
+      name,
+      creative_data: JSON.stringify(creativeData || {}),
+      preview_url: previewUrl,
+      status: 'pending'
+    });
+    res.json({ id: result.lastInsertRowid });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to create creative' });
+  }
+});
+
+router.get('/api/creatives/:id/preview', (req, res) => {
+  try {
+    const creative = statements.getCreative.get(req.params.id);
+    if (!creative) return res.status(404).json({ error: 'Not found' });
+    res.json({
+      id: creative.id,
+      creative_data: creative.creative_data ? JSON.parse(creative.creative_data) : {},
+      preview_url: creative.preview_url
+    });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to preview creative' });
+  }
+});
+
+router.post('/api/creatives/:id/publish', (req, res) => {
+  try {
+    statements.updateCreativeStatus.run({ id: req.params.id, status: 'published' });
+    res.json({ success: true });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to publish creative' });
+  }
+});
+
 // GET /admin - Serve admin dashboard
 router.get('/', (req, res) => {
   try {

--- a/src/routes/track.js
+++ b/src/routes/track.js
@@ -56,6 +56,14 @@ router.post('/', (req, res) => {
         clientInfo.referer
       );
 
+      if (req.app.locals.io) {
+        req.app.locals.io.emit('analytics', {
+          slot,
+          event: event.toLowerCase(),
+          timestamp: clientInfo.timestamp
+        });
+      }
+
       console.log(`📊 Tracked ${event} for slot: ${slot} (ID: ${result.lastInsertRowid})`);
 
       res.json({
@@ -97,6 +105,13 @@ router.get('/pixel', (req, res) => {
             clientInfo.ip,
             clientInfo.referer
           );
+          if (req.app.locals.io) {
+            req.app.locals.io.emit('analytics', {
+              slot,
+              event: 'impression',
+              timestamp: clientInfo.timestamp
+            });
+          }
           console.log(`📊 Pixel tracked impression for slot: ${slot}`);
         } catch (dbError) {
           console.error('Database error in pixel tracking:', dbError);
@@ -163,6 +178,14 @@ router.post('/batch', (req, res) => {
           clientInfo.ip,
           clientInfo.referer
         );
+
+        if (req.app.locals.io) {
+          req.app.locals.io.emit('analytics', {
+            slot: eventData.slot,
+            event: eventData.event.toLowerCase(),
+            timestamp: clientInfo.timestamp
+          });
+        }
 
         results.push({
           index: i,

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -8,7 +8,7 @@ describe('Integration Tests', () => {
   before(() => {
     process.env.DATABASE_PATH = ':memory:';
     process.env.ADMIN_PASSWORD = '';
-    app = require('../src/server');
+    app = require('../src/server').app;
   });
 
   test('GET /health returns ok', async () => {
@@ -41,6 +41,21 @@ describe('Integration Tests', () => {
     const res = await request(app).get('/admin/data');
     assert.strictEqual(res.statusCode, 200);
     assert.ok(Array.isArray(res.body));
+  });
+
+  test('GET /admin/api/formats returns formats', async () => {
+    const res = await request(app).get('/admin/api/formats');
+    assert.strictEqual(res.statusCode, 200);
+    assert.ok(Array.isArray(res.body));
+    assert.ok(res.body.length > 0);
+  });
+
+  test('POST /admin/api/campaigns creates campaign', async () => {
+    const res = await request(app)
+      .post('/admin/api/campaigns')
+      .send({ name: 'Test Campaign', format_id: 1 });
+    assert.strictEqual(res.statusCode, 200);
+    assert.ok(res.body.id);
   });
 
   test('GET unknown route returns 404', async () => {

--- a/test/performance.test.js
+++ b/test/performance.test.js
@@ -8,7 +8,7 @@ let app;
 describe('Performance Tests', () => {
   before(() => {
     process.env.DATABASE_PATH = ':memory:';
-    app = require('../src/server');
+    app = require('../src/server').app;
   });
 
   test('ad endpoint handles load quickly', async () => {

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -8,7 +8,7 @@ describe('Security Tests', () => {
   before(() => {
     process.env.DATABASE_PATH = ':memory:';
     process.env.RATE_LIMIT = '5';
-    app = require('../src/server');
+    app = require('../src/server').app;
   });
 
   test('rejects invalid slot input', async () => {


### PR DESCRIPTION
## Summary
- enhance SQLite schema with formats, campaigns, and creatives
- add Socket.IO server for realtime analytics
- extend admin routes with API endpoints for formats, campaigns and creatives
- modernize admin UI with tabbed sections and WebSocket updates
- add integration tests for new APIs

## Testing
- `npm run lint`
- `npm test`
- `docker build` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687807c8b470832b993982915d33c3ed