### PR TITLE
Implement advanced ad formats

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,15 @@
+import js from '@eslint/js';
+
+export default [
+  {
+    ...js.configs.recommended,
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    },
+    rules: {
+      'no-console': 'off',
+      semi: ['error', 'always']
+    }
+  }
+];

--- a/src/public/ad-formats.css
+++ b/src/public/ad-formats.css
@@ -1,0 +1,43 @@
+/* PushDown Animations */
+.lite-ad-pushdown {
+  transition: height 0.5s ease-in-out;
+  overflow: hidden;
+}
+
+.lite-ad-pushdown.expanded {
+}
+
+/* Interscroller Styles */
+.lite-ad-interscroller {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 9999;
+}
+
+/* Popup/Modal Styles */
+.lite-ad-popup {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10000;
+}
+
+/* In-page Notification Styles */
+.lite-ad-notification {
+  position: fixed;
+  animation: slideIn 0.3s ease-out;
+}
+
+/* Interstitial Styles */
+.lite-ad-interstitial {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 10001;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -8,8 +8,10 @@ require('dotenv').config();
 const adRoutes = require('./routes/ad');
 const trackRoutes = require('./routes/track');
 const adminRoutes = require('./routes/admin');
+const { initializeAdFormats } = require('./config');
 
 const app = express();
+initializeAdFormats();
 
 // Security middleware
 app.use(helmet({

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -7,6 +7,11 @@ describe('Database Configuration', () => {
   test('should initialize database successfully', () => {
     // Set test database path
     process.env.DATABASE_PATH = path.join(__dirname, '../data/test.db');
+
+    const fs = require('fs');
+    if (fs.existsSync(process.env.DATABASE_PATH)) {
+      fs.unlinkSync(process.env.DATABASE_PATH);
+    }
     
     // Require config after setting env variable
     const { db, statements } = require('../src/config');
@@ -64,7 +69,7 @@ describe('Tracking Data Validation', () => {
         return { valid: false, error: 'Event parameter is required and must be a string' };
       }
       
-      const allowedEvents = ['impression', 'click', 'viewable', 'loaded'];
+      const allowedEvents = ['impression', 'click', 'viewable', 'loaded', 'expand', 'close', 'skip'];
       if (!allowedEvents.includes(event.toLowerCase())) {
         return { valid: false, error: `Event must be one of: ${allowedEvents.join(', ')}` };
       }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -20,7 +20,7 @@ describe('Integration Tests', () => {
   test('GET /api/ad serves script', async () => {
     const res = await request(app).get('/api/ad').query({ slot: 'test-slot' });
     assert.strictEqual(res.statusCode, 200);
-    assert.match(res.text, /googletag/);
+    assert.match(res.text, /LiteAdServer.loadAd/);
   });
 
   test('POST /api/track saves event', async () => {


### PR DESCRIPTION
## Summary
- add ad format initialization and registration
- enhance ad route with advanced tag generation
- expand tracking system for format-specific events
- implement client-side format manager and styles
- update tests and lint config

## Testing
- `npm run lint`
- `npm test`
- `docker build -t lite-ad-server .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68780c9d0580832ba19e8b16ce6f4a03